### PR TITLE
Separate types into files

### DIFF
--- a/src/routes/Chart.tsx
+++ b/src/routes/Chart.tsx
@@ -4,10 +4,7 @@ import { fetchCoinHistory } from "../api";
 import ApexChart from "react-apexcharts";
 import { useRecoilValue } from "recoil";
 import { isDarkAtom } from "../atoms";
-
-interface IChartProps {
-  coinId: string;
-}
+import { IParams } from "../types";
 
 interface IHistorical {
   time_open: number;
@@ -23,7 +20,7 @@ interface IHistorical {
 interface IChartProps {}
 
 export const Chart = ({}: IChartProps) => {
-  const { coinId } = useOutletContext<IChartProps>();
+  const { coinId } = useOutletContext<IParams>();
   const { isLoading, data } = useQuery<IHistorical[]>(["ohlcv", coinId], () =>
     fetchCoinHistory(coinId)
   );

--- a/src/routes/Coin.tsx
+++ b/src/routes/Coin.tsx
@@ -11,6 +11,7 @@ import {
 import styled from "styled-components";
 import { useQuery } from "@tanstack/react-query";
 import { fetchCoinInfo, fetchCoinTickers } from "../api";
+import { IParams, IPriceData } from "../types";
 
 const Container = styled.div`
   padding: 0 20px;
@@ -103,10 +104,6 @@ const BackBtn = styled.button`
   }
 `;
 
-type Params = {
-  coinId: string;
-};
-
 interface RouterState {
   state: {
     name: string;
@@ -135,42 +132,8 @@ interface IInfoData {
   last_data_at: string;
 }
 
-interface IPriceData {
-  id: string;
-  name: string;
-  symbol: string;
-  rank: number;
-  circulating_supply: number;
-  total_supply: number;
-  max_supply: number;
-  beta_value: number;
-  first_data_at: string;
-  last_updated: string;
-  quotes: {
-    USD: {
-      ath_date: string;
-      ath_price: number;
-      market_cap: number;
-      market_cap_change_24h: number;
-      percent_change_1h: number;
-      percent_change_1y: number;
-      percent_change_6h: number;
-      percent_change_7d: number;
-      percent_change_12h: number;
-      percent_change_15m: number;
-      percent_change_24h: number;
-      percent_change_30d: number;
-      percent_change_30m: number;
-      percent_from_price_ath: number;
-      price: number;
-      volume_24h: number;
-      volume_24h_change_24h: number;
-    };
-  };
-}
-
 export const Coin: React.FC = () => {
-  const { coinId } = useParams<Params>();
+  const { coinId } = useParams<IParams>();
 
   // page끼리 데이터를 주고 받아야하는 경우
   // <Link to="/123" state={{ name: "Hello" }}> <- state를 전송

--- a/src/routes/Price.tsx
+++ b/src/routes/Price.tsx
@@ -2,6 +2,7 @@ import { useOutletContext } from "react-router-dom";
 import { fetchCoinTickers } from "../api";
 import { useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
+import { IParams, IPriceData } from "../types";
 
 const PriceBox = styled.div`
   background-color: rgba(0, 0, 0, 0.5);
@@ -16,46 +17,8 @@ const PriceTitle = styled.div`
   font-size: 28px;
 `;
 
-interface IPriceProps {
-  coinId: string;
-}
-
-interface IPriceData {
-  id: string;
-  name: string;
-  symbol: string;
-  rank: number;
-  circulating_supply: number;
-  total_supply: number;
-  max_supply: number;
-  beta_value: number;
-  first_data_at: string;
-  last_updated: string;
-  quotes: {
-    USD: {
-      ath_date: string;
-      ath_price: number;
-      market_cap: number;
-      market_cap_change_24h: number;
-      percent_change_1h: number;
-      percent_change_1y: number;
-      percent_change_6h: number;
-      percent_change_7d: number;
-      percent_change_12h: number;
-      percent_change_15m: number;
-      percent_change_24h: number;
-      percent_change_30d: number;
-      percent_change_30m: number;
-      percent_from_price_ath: number;
-      price: number;
-      volume_24h: number;
-      volume_24h_change_24h: number;
-    };
-  };
-}
-
 export const Price = () => {
-  const { coinId } = useOutletContext<IPriceProps>();
+  const { coinId } = useOutletContext<IParams>();
   const { isLoading, data } = useQuery<IPriceData>(
     ["price", coinId],
     () => fetchCoinTickers(coinId!),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,37 @@
+export interface IPriceData {
+  id: string;
+  name: string;
+  symbol: string;
+  rank: number;
+  circulating_supply: number;
+  total_supply: number;
+  max_supply: number;
+  beta_value: number;
+  first_data_at: string;
+  last_updated: string;
+  quotes: {
+    USD: {
+      ath_date: string;
+      ath_price: number;
+      market_cap: number;
+      market_cap_change_24h: number;
+      percent_change_1h: number;
+      percent_change_1y: number;
+      percent_change_6h: number;
+      percent_change_7d: number;
+      percent_change_12h: number;
+      percent_change_15m: number;
+      percent_change_24h: number;
+      percent_change_30d: number;
+      percent_change_30m: number;
+      percent_from_price_ath: number;
+      price: number;
+      volume_24h: number;
+      volume_24h_change_24h: number;
+    };
+  };
+}
+
+export type IParams = {
+  coinId: string;
+};


### PR DESCRIPTION
## 개요 💡
> 중복되는 타입, interface 선언들을 한 파일로 묶었습니다.

## 작업내용 ⌨️
- `src/types.ts` 파일에 `IPriceData` interface와 `IParams` type을 export 하여 다른 파일에서 사용 가능하게 하였습니다.
